### PR TITLE
Skip JUnit tests to fix failing android build

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -123,7 +123,7 @@ jobs:
 
         mv $INTEL_OPENVINO_DIR/runtime/lib/aarch64 $INTEL_OPENVINO_DIR/runtime/lib/arm64-v8a
 
-        ../../../gradle-7.4/bin/gradle clean build -x lint --info
+        ../../../gradle-7.4/bin/gradle clean build -x test -x lint --info
       working-directory: openvino_contrib/modules/java_api
 
     - name: Upload (ARM64)
@@ -200,7 +200,7 @@ jobs:
 
         mv $INTEL_OPENVINO_DIR/runtime/lib/intel64 $INTEL_OPENVINO_DIR/runtime/lib/x86_64
 
-        ../../../gradle-7.4/bin/gradle clean build -x lint --info
+        ../../../gradle-7.4/bin/gradle clean build -x test -x lint --info
       working-directory: openvino_contrib/modules/java_api
 
     - name: Upload (x86_64)


### PR DESCRIPTION
## Details

* Fix failing build due to gradle attempting to compile Junit tests https://github.com/dkurt/openvino_java/actions/runs/5219539621/jobs/9441828252?pr=22
* Explicitly disable JUnit tests on Android 

Fixes https://github.com/openvinotoolkit/openvino_contrib/pull/668#discussion_r1229010943
